### PR TITLE
Crusader Class Rebalance, Herald of God / Sacred Mission patch, Stone Discus and Tamruan Card Introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
   <!-- <link rel="shortcut icon" href="images/icon.gif" type="image/x-icon"> -->
   <link rel="canonical" href="https://rocalc.payonstories.com/" />
-  <link rel="stylesheet" type="text/css" href="public/style.css">
+  <link rel="stylesheet" type="text/css" href="style.css">
   <base target="_blank">
   <title>Payon Stories RO Calc</title>
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "npx -y rimraf public/src",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview"

--- a/src/card.js
+++ b/src/card.js
@@ -418,7 +418,8 @@ m_Card = [
     , [393, 5, "Yao Jun", 0, 9, 15, 10, 1, 0]
     , [394, 5, "Deviling", 0, 60, 50, 61, -50, 62, -50, 63, -50, 64, -50, 65, -50, 66, -50, 67, -50, 68, -50, 69, -50, 0]
     , [395, 7, "Dancing Dragon", 0, 2, 1, 10, 3, 0]
-    , [396, 3, "Tamruan", 0, 18, 2, 5158, 10, 5159, 10, 5384, 10, 0]
+    // Inflict 30% more damage with Shield Charge and Shield Boomerang.
+    , [396, 3, "Tamruan", 0, 18, 2, 5158, 30, 5159, 30, 5384, 30, 0]
     , [397, 2, "Leaf Cat", "1% chance to obtain a [Crystal Blue] item when killing a [" + v_Race[5] + "] race monster.", 61, 10, 0]
     , [398, 1, "Mao Guai / Civil Servant", 0, 48, 20, 0]
     , [399, 6, "Iron Fist", 0, 120, 10, 50, -20, 0]

--- a/src/foot.js
+++ b/src/foot.js
@@ -991,7 +991,8 @@ function StAllCalc() {
         10 == n_A_WeaponType && 15 == n_A_Arrow && (S += 20),
         (10 == n_A_WeaponType || 17 <= n_A_WeaponType && n_A_WeaponType <= 21) && (S += 15 * CardNumSearch(462)),
         SkillSearch(195) ? S += 7.5 + 2.5 * SkillSearch(195) : TimeItemNumSearch(34) && (S += 10),
-        SRV >= 50 && (4 != n_A_WeaponType && 5 != n_A_WeaponType || !SkillSearch(166) || (n_A_CRI += 3 * SkillSearch(166))),
+        // Spear Quicken: Add 1 CRIT per skill level
+        (4 == n_A_WeaponType || 5 == n_A_WeaponType) && SkillSearch(166) && (n_A_CRI += SkillSearch(166)),
         n_A_CRI += S,
         n_A_Buf3[5] && (n_A_CRI += 10 + n_A_Buf3[5] + Math.floor(n_A_Buf3[35] / 2) + Math.floor(n_A_Buf3[25] / 10)),
         11 == n_A_WeaponType && (n_A_CRI *= 2),

--- a/src/head.js
+++ b/src/head.js
@@ -4198,6 +4198,8 @@ function calc() {
     83 != n_A_ActiveSkill && 388 != n_A_ActiveSkill || !SkillSearch(381) || (w_HIT *= 1.5);
     7 == n_A_ActiveSkill && (w_HIT *= 1 + .1 * n_A_ActiveSkillLV);
     272 == n_A_ActiveSkill && (w_HIT *= 1 + .1 * n_A_ActiveSkillLV);
+    // Holy Cross skill has an accuracy bonus of +2% per skill level. (+20% at max level)
+    161 == n_A_ActiveSkill && (w_HIT *= 1 + .02 * n_A_ActiveSkillLV);
     337 == n_A_ActiveSkill && (w_HIT = 100);
     158 == n_A_ActiveSkill && (w_HIT = 100);
     // Shield Boomerang and Shield Charge can no longer miss.

--- a/src/head.js
+++ b/src/head.js
@@ -680,6 +680,7 @@ function BattleCalc999() {
             CastAndDelay(),
             BattleCalc998()
         } else if (159 == n_A_ActiveSkill || 384 == n_A_ActiveSkill) {
+            var stoneDiscusMod = EquipNumSearch(1371) ? 1 + .03 * n_A_LEFT_REFINE : 1;
             if (n_PerHIT_DMG = 0,
             n_rangedAtk = 1,
             n_A_Weapon_element = 0,
@@ -707,6 +708,7 @@ function BattleCalc999() {
                     w_DMG[_] = n_A_ATK_IP * wbairitu) : (w_DMG[_] = (o + Shieldw) * wbairitu,
                     w_DMG[_] = Math.floor(w_DMG[_] * defReduction(selectedMonster[14] - M_DEF1) - (n_B_DEF2[_] - M_DEF2))),
                     w_DMG[_] = Math.floor(w_DMG[_] * wbairitu2),
+                    w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
                     w_DMG[_] = ApplyModifiers(w_DMG[_]) + wSBr,
                     0 != M_DEF1 && (w_DMG[2] = w_DMG[1] = w_DMG[0]),
                     w_DMG[_] < 1 && (w_DMG[_] = 1),
@@ -721,6 +723,7 @@ function BattleCalc999() {
                 for (var _ = 0; 2 >= _; _++)
                     w_DMG[_] = n_A_ATK * wbairitu + Shieldw + wSBr,
                     w_DMG[_] = Math.floor(Math.floor(w_DMG[_] * defReduction(selectedMonster[14]) - n_B_DEF2[_]) * wbairitu2),
+                    w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
                     w_DMG[_] = ApplyModifiers(w_DMG[_]),
                     w_DMG[_] < 1 && (w_DMG[_] = 1),
                     w_DMG[_] = Math.floor(w_DMG[_] * element[selectedMonster[3]][0]),
@@ -731,6 +734,7 @@ function BattleCalc999() {
             CastAndDelay(),
             BattleCalc998()
         } else if (324 == n_A_ActiveSkill) {
+            var stoneDiscusMod = EquipNumSearch(90071) ? 1 + .03 * n_A_LEFT_REFINE : 1;
             if (n_PerHIT_DMG = 0,
             n_rangedAtk = 1,
             n_A_Weapon_element = 0,
@@ -747,6 +751,7 @@ function BattleCalc999() {
                 for (var _ = 0; 2 >= _; _++)
                     w_DMG[_] = s * wbairitu + Shieldw,
                     w_DMG[_] = Math.floor(Math.floor(5 * w_DMG[_] * defReduction(selectedMonster[14]) - n_B_DEF2[_]) * wbairitu2) + 5 * n_A_LEFT_REFINE * 2,
+                    w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
                     w_DMG[_] = ApplyModifiers(w_DMG[_]),
                     w_DMG[_] < 1 && (w_DMG[_] = 1),
                     305 == m_Item[n_A_Equip[5]][0] ? (w_DMG[_] = 0,
@@ -771,6 +776,7 @@ function BattleCalc999() {
                 for (var _ = 0; 2 >= _; _++)
                     w_DMG[_] = (n_A_ATK * defReduction(selectedMonster[14]) - n_B_DEF2[_]) * wbairitu2,
                     w_DMG[_] += wSC2[_],
+                    w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
                     w_DMG[_] = ApplyModifiers(w_DMG[_]),
                     w_DMG[_] < 1 && (w_DMG[_] = 1),
                     305 == m_Item[n_A_Equip[5]][0] && (w_DMG[_] = 0),
@@ -2016,6 +2022,13 @@ function BattleHiDam() {
     0 != wBHD)
         for (i = 0; 6 >= i; i++)
             w_HiDam[i] -= Math.floor(w_HiDam[i] * wBHD / 100);
+    // Apply Herald of God's refine-based mitigation (-2% damage taken per refine)
+    if (EquipNumSearch(433)) {
+        var refineCut = 2 * n_A_LEFT_REFINE;
+        if (refineCut > 0)
+            for (i = 0; 6 >= i; i++)
+                w_HiDam[i] -= Math.floor(w_HiDam[i] * refineCut / 100);
+    }
     if (wBHD = n_tok[190 + selectedMonster[4]],
     0 != wBHD)
         for (i = 0; 6 >= i; i++)
@@ -4181,6 +4194,12 @@ function calc() {
     }
 
     StAllCalc();
+
+    // Keep Shield Boomerang weight input in sync with the equipped shield so damage reflects current gear without manual input
+    if ((159 == n_A_ActiveSkill || 384 == n_A_ActiveSkill) && document.calcForm.SkillSubNum) {
+        var sbShield = m_Item[n_A_Equip[5]];
+        sbShield && (document.calcForm.SkillSubNum.value = sbShield[6]);
+    }
 
     // Multiplier on how the weapon equiped affects the monster selected
     wCSize = m_WeaponSize[n_A_WeaponType][selectedMonster[4]];

--- a/src/head.js
+++ b/src/head.js
@@ -685,7 +685,8 @@ function BattleCalc999() {
             n_A_Weapon_element = 0,
             Shieldw = 1 * c.SkillSubNum.value,
             n_Delay[2] = .7,
-            wbairitu2 = 1 + .3 * n_A_ActiveSkillLV,
+            // Shield Boomerang damage increased to (200 + 20 × SkillLV)%. (300% at max level).
+            wbairitu2 = 2 + .2 * n_A_ActiveSkillLV,
             384 == n_A_ActiveSkill && (n_Delay[2] = .35,
             wbairitu2 *= 2),
             SRV) {

--- a/src/head.js
+++ b/src/head.js
@@ -4199,6 +4199,9 @@ function calc() {
     7 == n_A_ActiveSkill && (w_HIT *= 1 + .1 * n_A_ActiveSkillLV);
     272 == n_A_ActiveSkill && (w_HIT *= 1 + .1 * n_A_ActiveSkillLV);
     337 == n_A_ActiveSkill && (w_HIT = 100);
+    158 == n_A_ActiveSkill && (w_HIT = 100);
+    // Shield Boomerang and Shield Charge can no longer miss.
+    (159 == n_A_ActiveSkill || 384 == n_A_ActiveSkill) && (w_HIT = 100);
     0 == SRV && 324 == n_A_ActiveSkill && (w_HIT += 20);
     384 == n_A_ActiveSkill && (w_HIT = 100);
     SkillSearch(364) && (w_HIT = 100);

--- a/src/head.js
+++ b/src/head.js
@@ -680,7 +680,8 @@ function BattleCalc999() {
             CastAndDelay(),
             BattleCalc998()
         } else if (159 == n_A_ActiveSkill || 384 == n_A_ActiveSkill) {
-            var stoneDiscusMod = EquipNumSearch(1371) ? 1 + .03 * n_A_LEFT_REFINE : 1;
+            var stoneDiscusMod = EquipNumSearch(1371) ? 1 + .03 * n_A_LEFT_REFINE : 1
+              , shieldRefineBonus = 10 * n_A_LEFT_REFINE;
             if (n_PerHIT_DMG = 0,
             n_rangedAtk = 1,
             n_A_Weapon_element = 0,
@@ -691,7 +692,6 @@ function BattleCalc999() {
             384 == n_A_ActiveSkill && (n_Delay[2] = .35,
             wbairitu2 *= 2),
             SRV) {
-                wSBr = 10 * n_A_LEFT_REFINE,
                 EquipNumSearch(620) || EquipNumSearch(409) || CardNumSearch(255) || EquipNumSearch(43) ? (M_DEF1 = selectedMonster[14],
                 M_DEF2 = n_B_DEF2[0]) : (EquipNumSearch(393) || EquipNumSearch(904)) && 7 == selectedMonster[2] ? (M_DEF1 = selectedMonster[14],
                 M_DEF2 = n_B_DEF2[0]) : (EquipNumSearch(392) || EquipNumSearch(401)) && 3 == selectedMonster[2] ? (M_DEF1 = selectedMonster[14],
@@ -709,7 +709,7 @@ function BattleCalc999() {
                     w_DMG[_] = Math.floor(w_DMG[_] * defReduction(selectedMonster[14] - M_DEF1) - (n_B_DEF2[_] - M_DEF2))),
                     w_DMG[_] = Math.floor(w_DMG[_] * wbairitu2),
                     w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
-                    w_DMG[_] = ApplyModifiers(w_DMG[_]) + wSBr,
+                    w_DMG[_] = ApplyModifiers(w_DMG[_]),
                     0 != M_DEF1 && (w_DMG[2] = w_DMG[1] = w_DMG[0]),
                     w_DMG[_] < 1 && (w_DMG[_] = 1),
                     305 == m_Item[n_A_Equip[5]][0] && (w_DMG[_] = 0),
@@ -717,11 +717,10 @@ function BattleCalc999() {
                     Last_DMG_A[_] = Last_DMG_B[_] = w_DMG[_],
                     InnStr[_] += Last_DMG_A[_]
             } else {
-                wSBr = 4 * n_A_LEFT_REFINE,
                 n_A_ATK_w = Math.round(Math.floor(n_A_STR / 10) * Math.floor(n_A_STR / 10)),
                 n_A_ATK = n_A_STR + n_A_ATK_w + Math.floor(n_A_DEX / 5) + Math.floor(n_A_LUK / 5);
                 for (var _ = 0; 2 >= _; _++)
-                    w_DMG[_] = n_A_ATK * wbairitu + Shieldw + wSBr,
+                    w_DMG[_] = n_A_ATK * wbairitu + Shieldw,
                     w_DMG[_] = Math.floor(Math.floor(w_DMG[_] * defReduction(selectedMonster[14]) - n_B_DEF2[_]) * wbairitu2),
                     w_DMG[_] = Math.floor(w_DMG[_] * stoneDiscusMod),
                     w_DMG[_] = ApplyModifiers(w_DMG[_]),
@@ -730,8 +729,13 @@ function BattleCalc999() {
                     Last_DMG_A[_] = Last_DMG_B[_] = w_DMG[_],
                     InnStr[_] += Last_DMG_A[_]
             }
-            w_DMG[1] = w_DMG[1] * w_HIT / 100,
-            CastAndDelay(),
+            // Add shield refine bonus after all modifiers so it still applies even if elemental mods reduce base damage to 0 (e.g., vs Ghost)
+            w_DMG[1] = w_DMG[1] * w_HIT / 100;
+            for (var _ = 0; 2 >= _; _++)
+                w_DMG[_] += shieldRefineBonus,
+                Last_DMG_A[_] = Last_DMG_B[_] = w_DMG[_],
+                InnStr[_] = Last_DMG_A[_];
+            CastAndDelay();
             BattleCalc998()
         } else if (324 == n_A_ActiveSkill) {
             var stoneDiscusMod = EquipNumSearch(90071) ? 1 + .03 * n_A_LEFT_REFINE : 1;

--- a/src/item.js
+++ b/src/item.js
@@ -433,7 +433,8 @@ m_Item = [
     , [430, 60, 70, 4, 0, 0, 220, 45, "Aebecee's Raging Typhoon Armor", 0, "", 198, 4, 0]
     , [431, 60, 65, 5, 0, "0/1", 110, 75, "Robe of Cast", 0, "", 19, 4, 73, -3, 0]
     , [432, 60, 1, 7, 0, 1, 250, 60, "Glittering Jacket", 0, "", 19, 5, 134, 3, 0]
-    , [433, 61, 113, 5, 0, "0/1", 160, 83, "Sacred Mission", 0, "", 3, 3, 4, 2, 19, 3, 194, 1, 0]
+    // Replace Sacred Mission -> Herald of God. Set INT+3, Weight: 250
+    , [433, 61, 113, 5, 0, "0/1", 250, 83, "Herald of God", 0, "A symbolic shield, rumored to have been given from God to his messenger. Per Refine, reduces damage from all sources by 2%", 3, 3, 4, 3, 19, 3, 17, 20, 194, 1, 5159, 30, 0]
     , [434, 61, 113, 5, 0, 0, 140, 68, "Holy Guard", 0, "", 3, 2, 19, 2, 0]
     , [435, 63, 51, 6, 0, 0, 35, 30, "Safety Boots", 0, "", 193, 1, 0]
     , [436, 62, 55, 0, 0, 0, 55, 75, "Survivor's Manteau", 0, "", 3, 10, 19, 5, 0]
@@ -1895,6 +1896,7 @@ m_Item = [
     , [1369, 9, 0, 2, 0, 1, 60, 0, "Staff of the Scholar", 0, "Ignores 15% of the enemy's MDEF", 4, 4, 89, 15, 20, 3, 0]
     // * Custom item Frozen pick
     , [1370, 1, 1, 52, 4, 0, 60, 36, "Frozen pick", 0, "[Missing properly increasing the damage at +8]", 9, -20, 18, -10, 23, 1, 0]
+    , [1371, 61, 113, 2, 0, 1, 150, 1, "Stone Discus", 0, "Increase damage of Shield Boomerang and Shield Charge by 3% per refine", 0]
 ];
 
 //[ id, display location, job that can use, atk/def, level of weapon, slots, weight, level required to use, "name of item", ?, "description", effect1, effect2, ..., 0 =? ]


### PR DESCRIPTION
You can visit https://ryeballar.github.io/rocalc/ to verify
- Adjust Shield Boomerang damage scaling to (200 + 20 × SkillLV)%. (300% at max level).
- Make Shield Boomerang and Shield Charge always hit
- Update Spear Quicken crit bonus to +1 per level
-  Buff Tamruan card shield skills to 30%
      DEF +2 retained.
      Shield Charge (skill 158) damage bonus increased to +30%.
      Shield Boomerang (skill 159) damage bonus increased to +30%.
      Shield Boomerang [Soul Linked] (skill 384) also set to +30%.
-  Add Holy Cross hit bonus per level
    Reference: Holy Cross Skill has an accuracy bonus of +2% per skill level. (+20% at max level)
-   Add Stone Discus shield for Crusader and Update Sacred Mission[0]/Herald of God Sync shield weight input and refine mitigation
-  Fix stylesheet link path
   Index is served from the public root already, so using public/style.css double-counts the folder and breaks the link; referencing style.css works from the document root.
- Add shield refine bonus post modifier for Shield Boomerang
- Adjust Shield Boomerang mastery handling
  