### PR TITLE
Re-balance: Acolyte Holy Light

### DIFF
--- a/src/head.js
+++ b/src/head.js
@@ -1358,9 +1358,9 @@ function BattleCalc999() {
             wCast = 1,
             n_Delay[2] = 1,
             wbairitu = .7 + .1 * n_A_ActiveSkillLV) : 37 == n_A_ActiveSkill || 387 == n_A_ActiveSkill ? (n_A_Weapon_element = 6,
-            wCast = 2,
+            wCast = 1.5,
             // * Holy light rebalance thx to Leole
-            wbairitu = 1 + (n_A_BaseLV + 1) / 100,
+            wbairitu = (n_A_BaseLV + 101) / 100,
             387 == n_A_ActiveSkill && (wbairitu *= 5)) : 104 == n_A_ActiveSkill ? (n_Delay[0] = 1,
             n_A_Weapon_element = 6,
             wHITsuu = n_A_ActiveSkillLV,


### PR DESCRIPTION
Changelog:

Update Holy Light skill:

- Does (101 + Base Level)% MATK. (200% at max base level)
- 1.5 Second Cast Time