### PR TITLE
Fix Super Novice “Save as URL” wiping equipment when Double Attack is set

### DIFF
--- a/src/foot.js
+++ b/src/foot.js
@@ -4106,7 +4106,8 @@ function URLIN() {
             a && (t = location.href.split("?")),
             _ && (t = location.href.split("#"));
         var a = t[1];
-        20 == StoN2(a.substr(1, 2)) && StoN2(a.substr(90, 1)) ? SuperNoviceFullWeaponCHECK = 1 : SuperNoviceFullWeaponCHECK = 0;
+        // Super Novice Spirit lives in skill slot 9 (skills start at offset 89)
+        20 == StoN2(a.substr(1, 2)) && StoN2(a.substr(89 + 9, 1)) ? SuperNoviceFullWeaponCHECK = 1 : SuperNoviceFullWeaponCHECK = 0;
         var A = StoN2(a.substr(0, 1));
         c.A_JOB.value = StoN2(a.substr(1, 2)),
             ClickJob(StoN2(a.substr(1, 2)), 2),


### PR DESCRIPTION
Description
- Selecting Super Novice and choosing any Double Attack level (>0) before “Save as URL” produced a link that, when opened, cleared all equipped gear.
- Root cause: URL decode logic restored the Super Novice full-weapon flag from the wrong skill slot (Double Attack slot 1 at offset 90). With Double Attack set, the flag was flipped on, which triggered `SuperNoviceFullWeapon()` early during load and reset equipment fields.
- Fix: Read the flag from the correct slot (Super Novice Spirit, skill index 9 at offset 89+9) and document the offset, so loading URLs no longer wipes equipment.

Steps to Reproduce (pre-fix) in https://rocalc.payonstories.com/
1) Open the simulator, pick job `Super Novice`.
2) Equip any items in multiple slots.
3) Set skill “Double Attack” to any level > 0.
4) Click “Save as URL”; copy/open the generated link (or refresh with the new hash).
5) Observe: gear slots are emptied.

Verification (post-fix) in https://ryeballar.github.io/rocalc
Repeat steps 1–4; gear remains intact after loading the saved URL.

